### PR TITLE
Hikey Patches

### DIFF
--- a/hikey_patches/OpenPlatformPkg.patch
+++ b/hikey_patches/OpenPlatformPkg.patch
@@ -1,0 +1,41 @@
+diff --git a/Platforms/Hisilicon/DeviceTree/hi6220-hikey.dtb b/Platforms/Hisilicon/DeviceTree/hi6220-hikey.dtb
+index 8e0872f..43c3802 100644
+Binary files a/Platforms/Hisilicon/DeviceTree/hi6220-hikey.dtb and b/Platforms/Hisilicon/DeviceTree/hi6220-hikey.dtb differ
+diff --git a/Platforms/Hisilicon/DeviceTree/hi6220-hikey.dts b/Platforms/Hisilicon/DeviceTree/hi6220-hikey.dts
+index e94fa1a..6dbbb1f 100644
+--- a/Platforms/Hisilicon/DeviceTree/hi6220-hikey.dts
++++ b/Platforms/Hisilicon/DeviceTree/hi6220-hikey.dts
+@@ -23,7 +23,7 @@
+ 	};
+ 
+ 	chosen {
+-		stdout-path = "serial3:115200n8";
++		stdout-path = "serial2:115200n8";
+ 	};
+ 
+ 	/*
+@@ -124,6 +124,11 @@
+ 	soc {
+ 		spi0: spi@f7106000 {
+ 			status = "ok";
++			tpm_tis_spi@0 {
++                            compatible = "tcg,tpm_tis-spi";
++                            spi-max-frequency = <5000000>;
++                            reg = <0>;
++                        };
+ 		};
+ 
+ 		i2c0: i2c@f7100000 {
+diff --git a/Platforms/Hisilicon/HiKey/HiKey.dsc b/Platforms/Hisilicon/HiKey/HiKey.dsc
+index 1e18c51..c126786 100644
+--- a/Platforms/Hisilicon/HiKey/HiKey.dsc
++++ b/Platforms/Hisilicon/HiKey/HiKey.dsc
+@@ -313,7 +313,7 @@
+   #
+ 
+   ## PL011 - Serial Terminal
+-  DEFINE SERIAL_BASE = 0xF7113000 # UART3
++  DEFINE SERIAL_BASE = 0xF7112000 # UART2
+   gEfiMdeModulePkgTokenSpaceGuid.PcdSerialRegisterBase|$(SERIAL_BASE)
+   gEfiMdePkgTokenSpaceGuid.PcdUartDefaultBaudRate|115200
+   gEfiMdePkgTokenSpaceGuid.PcdUartDefaultReceiveFifoDepth|0

--- a/hikey_patches/README
+++ b/hikey_patches/README
@@ -1,0 +1,32 @@
+1) Download source code for firmware as described at https://github.com/ARM-software/arm-trusted-firmware/blob/master/docs/plat/hikey.rst
+2) Links to download precompiled latest images. Note that there are patch files that can be used to enable TPM support and use of UART2
+   when secure96 board is connected. Uefi does not build dtbs and just uses the file as is. So for any dtb modifications we need to
+   build it in the kernel tree, copy it over to OpenPlatformPkg and then rebuild uefi with the new dtb file.
+	a) http://releases.linaro.org/96boards/hikey/linaro/debian/latest/ - for linux
+	b) http://releases.linaro.org/96boards/hikey/linaro/binaries/latest/ - firmware images
+3) Follow this link to unbrick or flash all images from scratch. mybuild.sh contains easy to use build script.
+	a) https://github.com/96boards/documentation/blob/master/consumer/hikey/installation/board-recovery.md
+	b) This link only flashes l-loader.bin and fip.bin. However,
+           https://github.com/96boards/documentation/blob/master/consumer/hikey/installation/linux-fastboot.md uses android fastboot
+           to flash the rest of the images line the boot efi image, rootfs, nvme etc. Android fastboot does not work if the host
+           machine is a VM over virtualbox.
+        c) To overcome the android fastboot issue, after step 3a) above, the board enters into atf-fastboot, and this can be passed
+           on to the VM over virtualbox successfully. The rest of the images, nvme, kernel, rootfs, boot etc etc can all be flashed
+           using atf-fastboot and there is no need to boot to android fastboot. Basically, all images can be flashed when the device
+           boots into fastboot when loading recovery.bin(which is atf-fastboot bl1.bin).
+4) Follow this link to build the kernel, and potentially modify device tree and use the new dtb file.
+	a) https://github.com/96boards/documentation/blob/master/consumer/hikey/build/linux-kernel.md
+	b) if dpkg does not work to create a package, you can build the kernel seperately and build the modules and directly transfer
+           it over to /boot.
+	c) Instructions to build kernel:
+		1) export ARCH=arm64
+		2) export CROSS_COMPILE=<path to arm64 linaro compiler>
+		3) make defconfig distro.config
+		4) make -j4 Image Image.gz dtbs modules LOCALVERSION=-hikey-linaro (Note: this can be split into as many steps but
+                   need to make sure LOCALVERSION is appeneded alwasy, otherwise you may see issues while loading modules since
+                   the version string may be different)
+		5) make -j4 modules_install LOCALVERSION=-hikey-linaro INSTALL_MOD_STRIP=1 INSTALL_MOD_PATH=<whatever location>
+5) Some other useful links:
+	a) https://discuss.96boards.org/t/booting-a-custon-kernel-on-lemaker-hikey/4554/5
+	b) https://github.com/96boards/documentation/wiki/LatestSnapshots
+	c) https://www.96boards.org/blog/getting-started-with-the-secure96-tpm/

--- a/hikey_patches/arm_trusted_firmware.patch
+++ b/hikey_patches/arm_trusted_firmware.patch
@@ -1,0 +1,27 @@
+diff --git a/plat/hisilicon/hikey/include/hikey_def.h b/plat/hisilicon/hikey/include/hikey_def.h
+index deb375da..5a6f9665 100644
+--- a/plat/hisilicon/hikey/include/hikey_def.h
++++ b/plat/hisilicon/hikey/include/hikey_def.h
+@@ -40,6 +40,7 @@
+  * PL011 related constants
+  */
+ #define PL011_UART0_BASE		0xF8015000
++#define PL011_UART2_BASE		0xF7112000
+ #define PL011_UART3_BASE		0xF7113000
+ #define PL011_BAUDRATE			115200
+ #define PL011_UART_CLK_IN_HZ		19200000
+diff --git a/plat/hisilicon/hikey/platform.mk b/plat/hisilicon/hikey/platform.mk
+index 38eb148c..e8fe154c 100644
+--- a/plat/hisilicon/hikey/platform.mk
++++ b/plat/hisilicon/hikey/platform.mk
+@@ -21,8 +21,8 @@ else
+   $(error "Currently unsupported HIKEY_TSP_RAM_LOCATION value")
+ endif
+ 
+-CONSOLE_BASE			:=	PL011_UART3_BASE
+-CRASH_CONSOLE_BASE		:=	PL011_UART3_BASE
++CONSOLE_BASE			:=	PL011_UART2_BASE
++CRASH_CONSOLE_BASE		:=	PL011_UART2_BASE
+ PLAT_PARTITION_MAX_ENTRIES	:=	12
+ PLAT_PL061_MAX_GPIOS		:=	160
+ COLD_BOOT_SINGLE_CPU		:=	1

--- a/hikey_patches/atf-fastboot.patch
+++ b/hikey_patches/atf-fastboot.patch
@@ -1,0 +1,27 @@
+diff --git a/plat/hikey/hikey_def.h b/plat/hikey/hikey_def.h
+index 2007633..a651890 100644
+--- a/plat/hikey/hikey_def.h
++++ b/plat/hikey/hikey_def.h
+@@ -80,6 +80,7 @@
+  * PL011 related constants
+  ******************************************************************************/
+ #define PL011_UART0_BASE		0xF8015000
++#define PL011_UART2_BASE		0xF7112000
+ #define PL011_UART3_BASE		0xF7113000
+ 
+ #define PL011_BAUDRATE			115200
+diff --git a/plat/hikey/platform.mk b/plat/hikey/platform.mk
+index f13854b..e9a8e9b 100644
+--- a/plat/hikey/platform.mk
++++ b/plat/hikey/platform.mk
+@@ -29,8 +29,8 @@
+ # POSSIBILITY OF SUCH DAMAGE.
+ #
+ 
+-CONSOLE_BASE		:=	PL011_UART3_BASE
+-CRASH_CONSOLE_BASE	:=	PL011_UART3_BASE
++CONSOLE_BASE		:=	PL011_UART2_BASE
++CRASH_CONSOLE_BASE	:=	PL011_UART2_BASE
+ 
+ # Process flags
+ $(eval $(call add_define,CONSOLE_BASE))

--- a/hikey_patches/linux_dts.patch
+++ b/hikey_patches/linux_dts.patch
@@ -1,0 +1,137 @@
+diff --git a/arch/arm64/boot/dts/hisilicon/hi6220-hikey.dts b/arch/arm64/boot/dts/hisilicon/hi6220-hikey.dts
+index e94fa1a53192..6dbbb1f25be0 100644
+--- a/arch/arm64/boot/dts/hisilicon/hi6220-hikey.dts
++++ b/arch/arm64/boot/dts/hisilicon/hi6220-hikey.dts
+@@ -23,7 +23,7 @@
+ 	};
+ 
+ 	chosen {
+-		stdout-path = "serial3:115200n8";
++		stdout-path = "serial2:115200n8";
+ 	};
+ 
+ 	/*
+@@ -124,6 +124,11 @@
+ 	soc {
+ 		spi0: spi@f7106000 {
+ 			status = "ok";
++			tpm_tis_spi@0 {
++                            compatible = "tcg,tpm_tis-spi";
++                            spi-max-frequency = <5000000>;
++                            reg = <0>;
++                        };
+ 		};
+ 
+ 		i2c0: i2c@f7100000 {
+diff --git a/drivers/char/tpm/tpm_tis_spi.c b/drivers/char/tpm/tpm_tis_spi.c
+index 424ff2fde1f2..f2f11332e3a2 100644
+--- a/drivers/char/tpm/tpm_tis_spi.c
++++ b/drivers/char/tpm/tpm_tis_spi.c
+@@ -41,7 +41,20 @@
+ #include "tpm.h"
+ #include "tpm_tis_core.h"
+ 
++#define APPLY_SLB9670_MODS 1
++
++#ifdef APPLY_SLB9670_MODS
++/*
++ * For SLB9670, the wait byte handling causes issues while talking to the TPM.
++ * The TPM works fine without the waitbyte handling since it never(almost?)
++ * sends the waitbyte. So we make the iobuffer 68 bytes since we can have
++ * a maximum of 64 bytes of data and 4 bytes for the command.
++ */
++#define MAX_SPI_FRAMESIZE 68
++#define MAX_SPI_DATASIZE 64
++#else
+ #define MAX_SPI_FRAMESIZE 64
++#endif
+ 
+ struct tpm_tis_spi_phy {
+ 	struct tpm_tis_data priv;
+@@ -63,11 +76,14 @@ static int tpm_tis_spi_transfer(struct tpm_tis_data *data, u32 addr, u16 len,
+ 	struct spi_message m;
+ 	struct spi_transfer spi_xfer;
+ 	u8 transfer_len;
+-
+ 	spi_bus_lock(phy->spi_device->master);
+ 
+ 	while (len) {
++#ifdef APPLY_SLB9670_MODS
++		transfer_len = min_t(u16, len, MAX_SPI_DATASIZE);
++#else
+ 		transfer_len = min_t(u16, len, MAX_SPI_FRAMESIZE);
++#endif
+ 
+ 		phy->iobuf[0] = (in ? 0x80 : 0) | (transfer_len - 1);
+ 		phy->iobuf[1] = 0xd4;
+@@ -77,6 +93,7 @@ static int tpm_tis_spi_transfer(struct tpm_tis_data *data, u32 addr, u16 len,
+ 		memset(&spi_xfer, 0, sizeof(spi_xfer));
+ 		spi_xfer.tx_buf = phy->iobuf;
+ 		spi_xfer.rx_buf = phy->iobuf;
++#ifndef APPLY_SLB9670_MODS
+ 		spi_xfer.len = 4;
+ 		spi_xfer.cs_change = 1;
+ 
+@@ -85,7 +102,6 @@ static int tpm_tis_spi_transfer(struct tpm_tis_data *data, u32 addr, u16 len,
+ 		ret = spi_sync_locked(phy->spi_device, &m);
+ 		if (ret < 0)
+ 			goto exit;
+-
+ 		if ((phy->iobuf[3] & 0x01) == 0) {
+ 			// handle SPI wait states
+ 			phy->iobuf[0] = 0;
+@@ -106,16 +122,25 @@ static int tpm_tis_spi_transfer(struct tpm_tis_data *data, u32 addr, u16 len,
+ 				goto exit;
+ 			}
+ 		}
+-
+ 		spi_xfer.cs_change = 0;
+ 		spi_xfer.len = transfer_len;
+ 		spi_xfer.delay_usecs = 5;
++#else
++		spi_xfer.cs_change = 1;
++		spi_xfer.len = transfer_len + 4;
++#endif
+ 
+ 		if (in) {
++#ifndef APPLY_SLB9670_MODS
+ 			spi_xfer.tx_buf = NULL;
++#endif
+ 		} else if (out) {
+ 			spi_xfer.rx_buf = NULL;
++#ifdef APPLY_SLB9670_MODS
++			memcpy(phy->iobuf + 4, out, transfer_len);
++#else
+ 			memcpy(phy->iobuf, out, transfer_len);
++#endif
+ 			out += transfer_len;
+ 		}
+ 
+@@ -126,7 +151,11 @@ static int tpm_tis_spi_transfer(struct tpm_tis_data *data, u32 addr, u16 len,
+ 			goto exit;
+ 
+ 		if (in) {
++#ifdef APPLY_SLB9670_MODS
++			memcpy(in, phy->iobuf + 4, transfer_len);
++#else
+ 			memcpy(in, phy->iobuf, transfer_len);
++#endif
+ 			in += transfer_len;
+ 		}
+ 
+@@ -211,8 +240,15 @@ static int tpm_tis_spi_probe(struct spi_device *dev)
+ 	if (!phy->iobuf)
+ 		return -ENOMEM;
+ 
++#ifdef APPLY_SLB9670_MODS
++	int retval = tpm_tis_core_init(&dev->dev, &phy->priv, -1, &tpm_spi_phy_ops,
++				 NULL);
++        pr_err("\nTPM TIS SPI Driver with SLB9670 mods: %d\n", retval);
++        return retval;
++#else
+ 	return tpm_tis_core_init(&dev->dev, &phy->priv, -1, &tpm_spi_phy_ops,
+ 				 NULL);
++#endif
+ }
+ 
+ static SIMPLE_DEV_PM_OPS(tpm_tis_pm, tpm_pm_suspend, tpm_tis_resume);

--- a/hikey_patches/mybuild.sh
+++ b/hikey_patches/mybuild.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+BUILD_PATH=`pwd`
+BUILD_OPTION=RELEASE
+export AARCH64_TOOLCHAIN=GCC5
+export UEFI_TOOLS_DIR=${BUILD_PATH}/uefi-tools
+export EDK2_DIR=${BUILD_PATH}/edk2
+EDK2_OUTPUT_DIR=${EDK2_DIR}/Build/HiKey/${BUILD_OPTION}_${AARCH64_TOOLCHAIN}
+# Build fastboot for Trusted Firmware-A. It's used for recovery mode.
+cd ${BUILD_PATH}/atf-fastboot
+CROSS_COMPILE=aarch64-linux-gnu- make PLAT=hikey DEBUG=1
+CROSS_COMPILE=aarch64-linux-gnu- make PLAT=hikey
+# Convert DEBUG/RELEASE to debug/release
+FASTBOOT_BUILD_OPTION=$(echo ${BUILD_OPTION} | tr '[A-Z]' '[a-z]')
+cd ${EDK2_DIR}
+# Build UEFI & Trusted Firmware-A
+#${UEFI_TOOLS_DIR}/uefi-build.sh -b ${BUILD_OPTION} -a ../arm-trusted-firmware -s ../optee_os hikey
+${UEFI_TOOLS_DIR}/uefi-build.sh -b ${BUILD_OPTION} -a ../arm-trusted-firmware hikey -v
+cd ${BUILD_PATH}/l-loader
+ln -sf ${EDK2_OUTPUT_DIR}/FV/bl1.bin
+ln -sf ${EDK2_OUTPUT_DIR}/FV/bl2.bin
+#ln -sf ${BUILD_PATH}/atf-fastboot/build/hikey/${FASTBOOT_BUILD_OPTION}/bl1.bin fastboot.bin
+ln -sf ${BUILD_PATH}/atf-fastboot/build/hikey/debug/bl1.bin fastboot.bin
+make hikey PTABLE_LST=linux-8g

--- a/hikey_patches/tpm_reset.c
+++ b/hikey_patches/tpm_reset.c
@@ -1,0 +1,57 @@
+/************************************************************/
+/* Toggle TPM Reset GPIO                      */
+/* Written with libsoc C library              */
+/*                             */
+/*                             */
+/* You can do interrupt programming with this library    */
+/*                             */
+/************************************************************/
+
+#include <stdio.h>
+#include <stdlib.h>
+
+#include "libsoc_gpio.h"
+/* #include "libsoc_debug.h" */
+#include "libsoc_board.h"
+
+unsigned int GPIO_RESET;
+
+/* This bit of code below makes this example work on all */
+/* 96Boards, Though you could just call this in main */
+__attribute__((constructor)) static void _init()
+{
+  board_config *config = libsoc_board_init();
+  GPIO_RESET = libsoc_board_gpio_id(config, "GPIO-D");
+  libsoc_board_free(config);
+}
+/* End of 96Boards special code */
+
+int main()
+{
+  gpio  *gpio_reset;
+
+  /* libsoc_set_debug(0); */
+  gpio_reset = libsoc_gpio_request(GPIO_RESET,LS_SHARED);
+
+  if (gpio_reset == NULL)
+  {
+    return(-1);
+  }
+  libsoc_gpio_set_direction(gpio_reset,OUTPUT);
+
+  if (libsoc_gpio_get_direction(gpio_reset) != OUTPUT)
+  {
+    return(-1);
+  }
+
+ libsoc_gpio_set_level(gpio_reset,1);
+ usleep(100000);
+ libsoc_gpio_set_level(gpio_reset,0);
+ usleep(100000);
+ libsoc_gpio_set_level(gpio_reset,1);
+ usleep(100000);
+ 
+  return EXIT_SUCCESS;
+}
+
+

--- a/hikey_patches/tpm_reset.sh
+++ b/hikey_patches/tpm_reset.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+# Based on secure96 schematics. The SLB9670's nRST(Reset) pin is connected to GPIO_D which is connected
+# to pin 26 of the Low Speed expansion slot. pin26 maps to pin number 491. see
+# http://wiki.lemaker.org/HiKey(LeMaker_version):How_to_control_the_GPIO_on_the_board for the magic behind
+# the conversion. Reset pin is active low. See slb9670 spec sheet and tpm_reset.c example from the bringup
+# of secure96 on the dragonboard410c.
+echo 491 > /sys/class/gpio/export
+echo out > /sys/class/gpio/gpio491/direction
+echo 1 > /sys/class/gpio/gpio491/value
+sleep 1
+echo 0 > /sys/class/gpio/gpio491/value
+sleep 1
+echo 1 > /sys/class/gpio/gpio491/value
+rmmod tpm_tis_spi.ko
+modprobe tpm_tis_spi


### PR DESCRIPTION
1) Hikey Kirin620 firmware patches to enable UART2.
2) Linux TPM driver and Hikey Device Tree patches to enable the
   secure96 boards TPM.
3) Readme on how to build and bring up the TPM.
4) Scripts to reset the TPM using GPIO from the command line.